### PR TITLE
Remove unnecessary dependency section

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,3 @@ adipiscing
 elit.
 --BREAK--
 ```
-
-# Dependencies
-* Tkinter
-
-I assume you have random built-in


### PR DESCRIPTION
`Tkinter` and `random` **are** built-in libraries. I think there's no need to list them as dependencies.